### PR TITLE
created a node counting binary for deduplication reducement calculations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,11 @@ add_executable(check-grammar
 )
 target_link_libraries(check-grammar PRIVATE do-verify)
 
+add_executable(count-nodes
+    src/count_nodes.cpp
+)
+target_link_libraries(count-nodes PRIVATE do-verify)
+
 add_executable(test-json src/json_read_main.cpp)
 target_link_libraries(test-json PRIVATE simdjson)
 

--- a/src/count_nodes.cpp
+++ b/src/count_nodes.cpp
@@ -1,0 +1,63 @@
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <vector>
+#include <do-verify/ptl.hpp>
+#include <do-verify/MTLEngine.hpp>
+
+using namespace do_verify;
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::cerr << "Usage: " << argv[0] << " <formulas.txt>" << std::endl;
+        return 1;
+    }
+
+    std::string filename = argv[1];
+    std::ifstream file(filename);
+    if (!file.is_open()) {
+        std::cerr << "Could not open file: " << filename << std::endl;
+        return 1;
+    }
+
+    std::string formula;
+    int sequential_nodes = 0;
+    int multi_nodes = 0;
+    
+    ptl_parser multi_parser;
+    auto multi_monitor = createDiscreteMultiPropertyMonitor(1000);
+
+    while (std::getline(file, formula)) {
+        if (formula.empty()) continue;
+        
+        try {
+            // Count nodes for this single formula with a fresh monitor
+            ptl_parser single_parser;
+            auto single_monitor = createDiscreteMultiPropertyMonitor(1000);
+            single_parser.parse_discrete(formula, single_monitor);
+            sequential_nodes += single_monitor.nodes.size();
+
+            // Accumulate in multi-property monitor
+            multi_parser.parse_discrete(formula, multi_monitor);
+        } catch (const std::exception& e) {
+            std::cerr << "Error parsing formula: " << formula << "\n" << e.what() << std::endl;
+            return 1;
+        }
+    }
+    
+    multi_nodes = multi_monitor.nodes.size();
+
+    std::cout << "=== Node Count Report: " << filename << " ===" << std::endl;
+    std::cout << "Sequential AST Nodes (Sum) : " << sequential_nodes << std::endl;
+    std::cout << "Deduplicated AST Nodes     : " << multi_nodes << std::endl;
+    
+    if (sequential_nodes > 0) {
+        double reduction_pct = 100.0 * (sequential_nodes - multi_nodes) / sequential_nodes;
+        double compression_factor = (double)sequential_nodes / multi_nodes;
+        std::cout << "Reduction                  : " << (sequential_nodes - multi_nodes) 
+                  << " nodes (" << reduction_pct << "%)" << std::endl;
+        std::cout << "AST Size Compression       : " << compression_factor << "x smaller" << std::endl;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This pull request introduces a new utility for analyzing the AST node count of formulas, along with the necessary build configuration. The main addition is the `count-nodes` executable, which reads formulas from a file, parses them both sequentially and as a multi-property, and reports on AST node deduplication and compression.

**New functionality:**

* Added a new executable, `count-nodes`, to the build system for analyzing AST node counts in formulas. (`CMakeLists.txt`)
* Implemented `src/count_nodes.cpp`, which:
  * Reads formulas from a file and parses each formula individually and collectively.
  * Reports the total number of AST nodes when parsed sequentially versus as a deduplicated multi-property.
  * Calculates and displays the node reduction and AST size compression factor.